### PR TITLE
fix proptype for dropzone element option

### DIFF
--- a/src/dropzone.jsx
+++ b/src/dropzone.jsx
@@ -5,7 +5,7 @@ class DropzoneElement extends Component {
     static propTypes = {
         children: PropTypes.node,
         dropActiveClassName: PropTypes.string,
-        element: PropTypes.string,
+        element: PropTypes.object,
         multiple: PropTypes.bool,
         onDropError: PropTypes.func,
         onProcessingDroppedFiles: PropTypes.func,


### PR DESCRIPTION
Fixes the PropType for dropzone components element option. It expects a DOM node, which is an object.