### PR TITLE
Replace deprecated react-addons-css-transition-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "gallery/index.js",
   "peerDependencies": {
     "react": "0.14.x || 15.x.x",
-    "react-addons-css-transition-group": "0.14.x || 15.x.x"
+    "react-transition-group": "1.1.x"
   },
   "dependencies": {
     "fine-uploader-wrappers": "1.0.0",
@@ -56,9 +56,9 @@
     "karma-webpack": "2.0.3",
     "pica": "2.0.8",
     "react": "15.4.2",
-    "react-addons-css-transition-group": "15.4.2",
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
+    "react-transition-group": "1.1.2",
     "style-loader": "0.16.0",
     "webpack": "2.3.2",
     "webpack-node-externals": "1.5.4"

--- a/src/gallery/index.jsx
+++ b/src/gallery/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import ReactCssTransitionGroup from 'react-addons-css-transition-group'
+import ReactCssTransitionGroup from 'react-transition-group/CSSTransitionGroup'
 
 import CancelButton from '../cancel-button'
 import DeleteButton from '../delete-button'
@@ -64,7 +64,7 @@ class Gallery extends Component {
                     const visibleFileIndex = this._findFileIndex(id)
                     if (visibleFileIndex < 0) {
                         visibleFiles.push({ id, fromServer: true })
-                    } 
+                    }
                 }
                 this._updateVisibleFileStatus(id, status)
             }


### PR DESCRIPTION
The `react-addons-css-transition-group` is deprecated and will no longer work with React 16+, see https://www.npmjs.com/package/react-addons-css-transition-group.

The package has been replaced with the `react-transition-group` package found here https://github.com/reactjs/react-transition-group. There should be no changes to any funcionality.