### PR TITLE
Update to react-transition-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "gallery/index.js",
   "peerDependencies": {
     "react": "0.14.x || 15.x.x",
-    "react-addons-css-transition-group": "0.14.x || 15.x.x",
+    "react-transition-group": "1.x.x",
     "prop-types": "15.x.x"
   },
   "dependencies": {
@@ -57,7 +57,6 @@
     "karma-webpack": "2.0.3",
     "pica": "2.0.8",
     "react": "15.4.2",
-    "react-addons-css-transition-group": "15.4.2",
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
     "prop-types": "15.5.8",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react": "15.4.2",
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
+    "react-transition-group": "1.2.0",
     "prop-types": "15.5.8",
     "style-loader": "0.16.0",
     "webpack": "2.3.2",

--- a/src/gallery/index.jsx
+++ b/src/gallery/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ReactCssTransitionGroup from 'react-addons-css-transition-group'
+import { CSSTransitionGroup as ReactCssTransitionGroup } from 'react-transition-group'
 
 import CancelButton from '../cancel-button'
 import DeleteButton from '../delete-button'


### PR DESCRIPTION
With the release of [React 15.5](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#discontinuing-support-for-react-addons) there are a few add-ons which have been moved to separate repositories. For some it means they are already migrating to its new namespace. 

At the moment `react-fine-uploader` has a peerDependency to the discontinued add-on `react-addons-css-transition-group`, whereas some projects may already have migrated to `react-transition-group` namespace. This PR continues on the `react-transition-group` namespace.