### PR TITLE
Fix Dropzone documentation in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ A _very_ simple but completely functional and effective use of the `<Dropzone />
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import FileInput from 'react-fine-uploader/dropzone'
+import Dropzone from 'react-fine-uploader/dropzone'
 import FineUploaderTraditional from 'fine-uploader-wrappers'
 
 const uploader = new FineUploaderTraditional({


### PR DESCRIPTION
I was getting a strange error trying to use the example code for a simple dropzone implementation. I noticed the import command was referencing an unrelated component and changing it fixed my problem.