### PR TITLE
React v16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   ],
   "main": "gallery/index.js",
   "peerDependencies": {
-    "react": "0.14.x || 15.x.x",
+    "react": "0.14.x - 16.x",
     "react-transition-group": "1.x",
-    "prop-types": "15.x.x"
+    "prop-types": "15.x"
   },
   "dependencies": {
     "fine-uploader-wrappers": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fine-uploader",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "license": "MIT",
   "description": "React UI components for using Fine Uploader in a React-based project.",
   "author":     {
@@ -26,7 +26,7 @@
     "prop-types": "15.x"
   },
   "dependencies": {
-    "fine-uploader-wrappers": "1.0.1",
+    "fine-uploader-wrappers": "^1.0.1",
     "object-assign": "4.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "gallery/index.js",
   "peerDependencies": {
     "react": "0.14.x || 15.x.x",
-    "react-transition-group": "1.x.x",
+    "react-transition-group": "1.x",
     "prop-types": "15.x.x"
   },
   "dependencies": {


### PR DESCRIPTION
Attempt to fix peerDependency not met issue I encountered working with the package in React 16.

Mentioned:
https://github.com/FineUploader/react-fine-uploader/issues/166